### PR TITLE
NO-ISSUE - Fix `BYDAY` implementation

### DIFF
--- a/Sources/JavaScriptBridge.swift
+++ b/Sources/JavaScriptBridge.swift
@@ -117,9 +117,7 @@ internal extension RecurrenceRule {
             jsonString += "bymonthday: [\(bymonthdayStrings.joined(separator: ","))],"
         }
 
-        let byweekdayJSSymbols = byweekday.map({ (weekday) -> String in
-            return weekday.toJSONSymbol()
-        })
+        let byweekdayJSSymbols = byweekday.map { $0.weekday.toJSONSymbol() }
         if byweekdayJSSymbols.count > 0 {
             jsonString += "byweekday: [\(byweekdayJSSymbols.joined(separator: ","))],"
         }

--- a/Sources/JavaScriptBridge.swift
+++ b/Sources/JavaScriptBridge.swift
@@ -52,6 +52,15 @@ internal extension EKWeekday {
     }
 }
 
+internal extension RecurrenceRule.ByDay {
+    
+    fileprivate func toJSONSymbol() -> String {
+        
+        guard let cardinality, cardinality != 0 else { return weekday.toJSONSymbol()}
+        return "\(weekday.toJSONSymbol()).nth(\(String(cardinality)))"
+    }
+}
+
 internal extension RecurrenceRule {
     func toJSONString(endless endlessRecurrenceCount: Int) -> String {
         var jsonString = "freq: \(frequency.toJSONFrequency()),"
@@ -117,7 +126,7 @@ internal extension RecurrenceRule {
             jsonString += "bymonthday: [\(bymonthdayStrings.joined(separator: ","))],"
         }
 
-        let byweekdayJSSymbols = byweekday.map { $0.weekday.toJSONSymbol() }
+        let byweekdayJSSymbols = byweekday.map { $0.toJSONSymbol() }
         if byweekdayJSSymbols.count > 0 {
             jsonString += "byweekday: [\(byweekdayJSSymbols.joined(separator: ","))],"
         }

--- a/Sources/RecurrenceRule.swift
+++ b/Sources/RecurrenceRule.swift
@@ -100,7 +100,15 @@ public extension RecurrenceRule {
     // so we need to parse the cardinality and the weekday of the rule
     struct ByDay {
 
-        var cardinality: Int?
-        var weekday: EKWeekday
+        public var cardinality: Int?
+        public var weekday: EKWeekday
+        
+        public init(
+            cardinality: Int? = nil,
+            weekday: EKWeekday
+        ) {
+            self.cardinality = cardinality
+            self.weekday = weekday
+        }
     }
 }

--- a/Sources/RecurrenceRule.swift
+++ b/Sources/RecurrenceRule.swift
@@ -60,7 +60,7 @@ public struct RecurrenceRule {
     public var bymonthday = [Int]()
 
     /// The days of the week associated with the recurrence rule, as an array of EKWeekday objects.
-    public var byweekday = [EKWeekday]()
+    public var byweekday = [RecurrenceRule.ByDay]()
 
     /// The hours of the day associated with the recurrence rule, as an array of integers.
     public var byhour = [Int]()
@@ -91,5 +91,16 @@ public struct RecurrenceRule {
 
     public func toRRuleString() -> String {
         return RRule.stringFromRule(self)
+    }
+}
+
+public extension RecurrenceRule {
+
+    // this rule can be specified like `BYDAY=2TU`, which means "every second tuesday"
+    // so we need to parse the cardinality and the weekday of the rule
+    struct ByDay {
+
+        var cardinality: Int?
+        var weekday: EKWeekday
     }
 }


### PR DESCRIPTION
On recurrence rules like `RRULE:FREQ=MONTHLY;BYDAY=2TU` that contain a "cardinality" in the `BYDAY` rule, the library would not parse correctly.

- Created `RecurrenceRule.ByDay`
- Update the parsing
- Convert the recurrence to json in order to feed to the javascript bridge