### PR TITLE
NO-ISSUE - Use `RRuleSet` to parse complex rules (including `EXDATE`)

### DIFF
--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -128,17 +128,17 @@ public enum RRuleSet {
         let untilDateJSON = RRule.ISO8601DateFormatter.string(from: untilDate)
         let dtStartISOString = RRule.ISO8601DateFormatter.string(from: dtStart)
 
-        let _ = RRuleSwiftIterator.rruleContext?.evaluateScript("var dtstart = new Date('\(dtStartISOString)');")
-        let dtStartRuleScript = "RRule.optionsToString({ dtstart });"
-        let dtStartRuleString = RRuleSwiftIterator.rruleContext?.evaluateScript(dtStartRuleScript).toString()
-        let allRules = [dtStartRuleString] + rules
-        let normalizedRecurrenceRules = allRules.compactMap { $0 }.joined(separator: "\\n")
+//        let _ = RRuleSwiftIterator.rruleContext?.evaluateScript("var dtstart = new Date('\(dtStartISOString)');")
+//        let dtStartRuleScript = "RRule.optionsToString({ dtstart });"
+//        let dtStartRuleString = RRuleSwiftIterator.rruleContext?.evaluateScript(dtStartRuleScript).toString()
+//        let allRules = [dtStartRuleString] + rules
+//        let normalizedRecurrenceRules = allRules.compactMap { $0 }.joined(separator: "\\n")
+        let normalizedRecurrenceRules = rules.joined(separator: "\\n")
 
-        print("[RRuleSwift] rules: \(allRules)")
+        print("[RRuleSwift] rules: \(rules)")
 
         let rruleSetScript =
-            "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { cache: false });"
-
+            "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { cache: false, dtstart: new Date('\(dtStartISOString)') });"
 
         let _ = RRuleSwiftIterator.rruleContext?.evaluateScript(rruleSetScript)
 

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -103,6 +103,7 @@ public extension RecurrenceRule {
 public extension Collection where Element == RecurrenceRule {
 
     func occurrences(
+        dtStart: Date?,
         between date: Date,
         and otherDate: Date,
         endless endlessRecurrenceCount: Int = RRuleSwiftIterator.endlessRecurrenceCount
@@ -118,6 +119,12 @@ public extension Collection where Element == RecurrenceRule {
         let untilDateJSON = RRule.ISO8601DateFormatter.string(from: untilDate)
 
         let _ = RRuleSwiftIterator.rruleContext?.evaluateScript("const rruleSet = new RRuleSet();")
+
+        if let dtStart {
+            let dtStartString = RRule.ISO8601DateFormatter.string(from: dtStart)
+            let script = "rruleSet.rrule(RRule.fromString(RRule.optionsToString({ dtstart: \(dtStartString) })));"
+            let _ = RRuleSwiftIterator.rruleContext?.evaluateScript(script)
+        }
 
         for rule in self {
             let ruleString = rule.toJSONString(endless: endlessRecurrenceCount)

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -112,7 +112,7 @@ public enum RRuleSet {
 
     public static func occurrences(
         rules: [String],
-        dtStart: Date? = nil,
+        dtStart: Date,
         between date: Date,
         and otherDate: Date,
         endless endlessRecurrenceCount: Int = RRuleSwiftIterator.endlessRecurrenceCount
@@ -126,27 +126,18 @@ public enum RRuleSet {
         let untilDate = otherDate.isAfterOrSame(with: date) ? otherDate : date
         let beginDateJSON = RRule.ISO8601DateFormatter.string(from: beginDate)
         let untilDateJSON = RRule.ISO8601DateFormatter.string(from: untilDate)
+        let dtStartISOString = RRule.ISO8601DateFormatter.string(from: dtStart)
 
-//        if let dtStart {
-//            let dtStartISOString = RRule.ISO8601DateFormatter.string(from: dtStart)
-//            let dtStartRuleScript = "RRule.optionsToString({ dtstart: new Date('\(dtStartISOString)') })"
-//            let dtStartRuleString = RRuleSwiftIterator.rruleContext?.evaluateScript(dtStartRuleScript).toString()
-//            // rules += [dtStartRuleString].compactMap { $0 }
-//        }
+        let _ = RRuleSwiftIterator.rruleContext?.evaluateScript("var dtstart = new Date('\(dtStartISOString)');")
+        let dtStartRuleScript = "RRule.optionsToString({ dtstart });"
+        let dtStartRuleString = RRuleSwiftIterator.rruleContext?.evaluateScript(dtStartRuleScript).toString()
+        let allRules = [dtStartRuleString] + rules
+        let normalizedRecurrenceRules = allRules.compactMap { $0 }.joined(separator: "\n")
 
-        let normalizedRecurrenceRules = rules.joined(separator: "\n")
-        let rruleSetScript: String
+        let rruleSetScript =
+            "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { forceset: true, cache: false, dtstart });"
 
-        if let dtStart {
-            let dtStartISOString = RRule.ISO8601DateFormatter.string(from: dtStart)
-            rruleSetScript =
-                "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { forceset: true, cache: false, dtstart: RRule.optionsToString({ dtstart: new Date('\(dtStartISOString)') }) });"
-        } else {
-            rruleSetScript =
-                "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { forceset: true, cache: false });"
-        }
-
-        print("[RRuleSwift] rules: \(rules)")
+        print("[RRuleSwift] rules: \(normalizedRecurrenceRules)")
 
         let _ = RRuleSwiftIterator.rruleContext?.evaluateScript(rruleSetScript)
 

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -25,6 +25,7 @@ public struct Iterator {
 
         // this is a hack to import RRule so that it can be used throughout 😬
         let _ = context?.evaluateScript("var RRule = this.rrule.RRule;")
+        let _ = context?.evaluateScript("var RRuleSet = this.rrule.RRuleSet;")
         return context
     }()
 }

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -132,7 +132,7 @@ public enum RRuleSet {
         let dtStartRuleScript = "RRule.optionsToString({ dtstart });"
         let dtStartRuleString = RRuleSwiftIterator.rruleContext?.evaluateScript(dtStartRuleScript).toString()
         let allRules = [dtStartRuleString] + rules
-        let normalizedRecurrenceRules = allRules.compactMap { $0 }.joined(separator: "\n")
+        let normalizedRecurrenceRules = allRules.compactMap { $0 }.joined(separator: "\\n")
 
         print("[RRuleSwift] rules: \(allRules)")
 

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -121,7 +121,7 @@ public extension Collection where Element == RecurrenceRule {
         let beginDateJSON = RRule.ISO8601DateFormatter.string(from: beginDate)
         let untilDateJSON = RRule.ISO8601DateFormatter.string(from: untilDate)
 
-        let _ = RRuleSwiftIterator.rruleContext?.evaluateScript("const rruleSet = new RRuleSet();")
+        let _ = RRuleSwiftIterator.rruleContext?.evaluateScript("var rruleSet = new RRuleSet();")
 
         if let dtStart {
             let dtStartString = RRule.ISO8601DateFormatter.string(from: dtStart)

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -125,7 +125,7 @@ public extension Collection where Element == RecurrenceRule {
 
         if let dtStart {
             let dtStartString = RRule.ISO8601DateFormatter.string(from: dtStart)
-            let script = "rruleSet.rrule(RRule.fromString(RRule.optionsToString({ dtstart: \(dtStartString) })));"
+            let script = "rruleSet.rrule(RRule.fromString(RRule.optionsToString({ dtstart: new Date('\(dtStartString)') })));"
             let _ = RRuleSwiftIterator.rruleContext?.evaluateScript(script)
         }
 

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -9,6 +9,8 @@
 import Foundation
 import JavaScriptCore
 
+public typealias RRuleSwiftIterator = Iterator
+
 public struct Iterator {
     public static let endlessRecurrenceCount = 500
     internal static let rruleContext: JSContext? = {

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -140,10 +140,10 @@ public enum RRuleSet {
         if let dtStart {
             let dtStartISOString = RRule.ISO8601DateFormatter.string(from: dtStart)
             rruleSetScript =
-                "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { forceset: true, cache: false, dtstart: RRule.optionsToString({ dtstart: new Date('\(dtStartISOString)') }) }) as RRuleSet;"
+                "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { forceset: true, cache: false, dtstart: RRule.optionsToString({ dtstart: new Date('\(dtStartISOString)') }) });"
         } else {
             rruleSetScript =
-                "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { forceset: true, cache: false }) as RRuleSet;"
+                "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { forceset: true, cache: false });"
         }
 
         print("[RRuleSwift] rules: \(rules)")

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -137,10 +137,10 @@ public enum RRuleSet {
         let normalizedRecurrenceRules = rules.joined(separator: "\n")
 
         let rruleSetScript = """
-            var rruleSet = rrulestr('\(normalizedRecurrenceRules)', {
-                forceset: true,
-                cache: false,
-                dtstart,
+            var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { \
+                forceset: true, \
+                cache: false, \
+                dtstart, \
             }) as RRuleSet;
             """
 

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -131,11 +131,11 @@ public extension Collection where Element == RecurrenceRule {
 
         for rule in self {
             let ruleJSONString = rule.toJSONString(endless: endlessRecurrenceCount)
-            let script = "rruleSet.rrule(new RRule({ \(ruleJSONString) });"
+            let script = "rruleSet.rrule(new RRule({ \(ruleJSONString) }));"
             let _ = RRuleSwiftIterator.rruleContext?.evaluateScript(script)
         }
 
-        let betweenScript = "rruleSet.between(new Date('\(beginDateJSON)'), new Date('\(untilDateJSON)'), true)"
+        let betweenScript = "rruleSet.between(new Date('\(beginDateJSON)'), new Date('\(untilDateJSON)'), true);"
 
         guard
             let betweenOccurrences = RRuleSwiftIterator.rruleContext?.evaluateScript(betweenScript).toArray() as? [Date]

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -106,7 +106,7 @@ public extension RecurrenceRule {
 
 public enum RRuleSet {
 
-    func occurrences(
+    public func occurrences(
         rules: [String],
         dtStart: Date? = nil,
         between date: Date,

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -134,10 +134,11 @@ public enum RRuleSet {
         let allRules = [dtStartRuleString] + rules
         let normalizedRecurrenceRules = allRules.compactMap { $0 }.joined(separator: "\n")
 
-        let rruleSetScript =
-            "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { forceset: true, cache: false, dtstart });"
+        print("[RRuleSwift] rules: \(allRules)")
 
-        print("[RRuleSwift] rules: \(normalizedRecurrenceRules)")
+        let rruleSetScript =
+            "var rruleSet = rrulestr('\(normalizedRecurrenceRules)', { cache: false });"
+
 
         let _ = RRuleSwiftIterator.rruleContext?.evaluateScript(rruleSetScript)
 

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -130,8 +130,8 @@ public extension Collection where Element == RecurrenceRule {
         }
 
         for rule in self {
-            let ruleString = rule.toJSONString(endless: endlessRecurrenceCount)
-            let script = "rruleSet.rrule(new RRule({ \(ruleString)) });"
+            let ruleJSONString = rule.toJSONString(endless: endlessRecurrenceCount)
+            let script = "rruleSet.rrule(new RRule({ \(ruleJSONString) });"
             let _ = RRuleSwiftIterator.rruleContext?.evaluateScript(script)
         }
 

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -106,7 +106,7 @@ public extension RecurrenceRule {
 
 public enum RRuleSet {
 
-    public func occurrences(
+    static public func occurrences(
         rules: [String],
         dtStart: Date? = nil,
         between date: Date,


### PR DESCRIPTION
Using the simple `RRule` parsing wasn't allowing us to parse `EXDATE` rules.

@vkartaviy pointed out that these are now supported with `RRuleSet` API 🙏 